### PR TITLE
fix: nvim binaries

### DIFF
--- a/modules/editors/nvim.nix
+++ b/modules/editors/nvim.nix
@@ -15,9 +15,47 @@
   };
   home = {
     packages = with pkgs; [
+      # functionalities
       luajitPackages.luarocks
       deno
       lazygit
+      # LSPs
+      nodePackages_latest.bash-language-server
+      nodePackages_latest.dockerfile-language-server-nodejs
+      clang-tools
+      nodePackages_latest.vscode-langservers-extracted
+      gopls
+      lua-language-server
+      marksman
+      nil
+      pyright
+      rust-analyzer
+      texlab
+      nodePackages_latest.typescript-language-server
+      typst-lsp
+      nodePackages.yaml-language-server
+      # tree-sitter
+      tree-sitter
+      # format
+      stylua
+      black
+      isort
+      nixpkgs-fmt
+      rustfmt
+      beautysh
+      shfmt
+      nodePackages.prettier
+      # linters
+      shellcheck
+      shellharden
+      luajitPackages.luacheck
+      ruff
+      nodePackages.markdownlint-cli
+      proselint
+      alex
+      nodePackages.write-good
+      # debug
+      lldb
     ];
   };
 }


### PR DESCRIPTION
Adds the nvim LSP/Linter/Formatter packages instead of relying on Mason.

Mason binaries are a little broken on NixOS (check: https://github.com/williamboman/mason.nvim/issues/428)

Related: https://github.com/realeinherjar/nvim/pull/1

Closes: #33.