### PR TITLE
fix: Mullvad VPN persistence rettings

### DIFF
--- a/hosts/laptop/wayland/default.nix
+++ b/hosts/laptop/wayland/default.nix
@@ -75,6 +75,7 @@
         "/etc/nixos" # bind mounted from /nix/persist/etc/nixos to /etc/nixos
         "/etc/NetworkManager/system-connections"
         "/etc/wireguard"
+        "/etc/mullvad-vpn"
         "/var/log"
         "/var/lib"
       ];


### PR DESCRIPTION
Adds `/etc/mullvad-vpn` to the persistence whitelist.

Closes #29.