### PR TITLE
fix: Limit boot configs to 20  

### DIFF
--- a/hosts/laptop-minimal/default.nix
+++ b/hosts/laptop-minimal/default.nix
@@ -26,7 +26,7 @@
       systemd-boot = {
         enable = true;
         consoleMode = "auto";
-        configurationLimit=20;
+        configurationLimit = 20;
       };
       efi = {
         canTouchEfiVariables = true;

--- a/hosts/laptop-minimal/default.nix
+++ b/hosts/laptop-minimal/default.nix
@@ -26,6 +26,7 @@
       systemd-boot = {
         enable = true;
         consoleMode = "auto";
+        configurationLimit=20;
       };
       efi = {
         canTouchEfiVariables = true;

--- a/hosts/laptop/wayland/default.nix
+++ b/hosts/laptop/wayland/default.nix
@@ -43,6 +43,7 @@
       systemd-boot = {
         enable = true;
         consoleMode = "auto";
+        configurationLimit=20;
       };
       efi = {
         canTouchEfiVariables = true;


### PR DESCRIPTION
The default is "null", aka, no limit. This is bad for long-term.
