### PR TITLE
feat(yazi,hypr,eza): update home-manager

### DIFF
--- a/modules/desktop/hyprland/home.nix
+++ b/modules/desktop/hyprland/home.nix
@@ -22,7 +22,7 @@
   wayland.windowManager.hyprland = {
     enable = true;
     systemdIntegration = true;
-    nvidiaPatches = false;
+    enableNvidiaPatches = false;
     extraConfig = ''
       $mainMod = SUPER
       # $scripts=$HOME/.config/hypr/scripts

--- a/modules/programs/common/default.nix
+++ b/modules/programs/common/default.nix
@@ -11,4 +11,5 @@
   ./zathura
   ./foot
   ./transmission
+  ./just
 ]

--- a/modules/programs/common/just/default.nix
+++ b/modules/programs/common/just/default.nix
@@ -1,0 +1,5 @@
+{ config, lib, pkgs, ... }:
+
+{
+  home = { packages = with pkgs; [ just ]; };
+}

--- a/modules/programs/common/search/default.nix
+++ b/modules/programs/common/search/default.nix
@@ -7,7 +7,7 @@
       tree
       fd
       ripgrep
-      exa
+      eza
       mediainfo
       exiftool
       file

--- a/modules/programs/common/search/default.nix
+++ b/modules/programs/common/search/default.nix
@@ -38,6 +38,6 @@
       enable = true;
       enableFishIntegration = true;
     };
-    # yazi = { enable = true; };
+    yazi = { enable = true; };
   };
 }

--- a/modules/shell/fish/functions/l.nix
+++ b/modules/shell/fish/functions/l.nix
@@ -1,5 +1,5 @@
 ''
   function l
-      ls -ahl $argv
+      eza -ahl $argv
   end
 ''

--- a/modules/shell/fish/functions/ls.nix
+++ b/modules/shell/fish/functions/ls.nix
@@ -1,5 +1,5 @@
 ''
   function ls 
-      exa $argv
+      eza $argv
   end
 ''


### PR DESCRIPTION
- `eza`: `exa` is deprecated, `eza` is the community maintained fork
- `hypr`: `nvidiaPatches` is now `enableNvidiaPatches`
- `yazi`: now its possible to add it, closes #49.
- `just`: add `just`.